### PR TITLE
Add deployment pipelines using gh action and docker

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,7 +24,7 @@ jobs:
               uses: docker/build-push-action@v5
               with:
                   context: ./apps/api
-                  file: ./Dockerfile
+                  file: ./apps/api/Dockerfile
                   push: true
                   tags: |
                       satriadhikara/jejak-api:latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,31 @@
+name: Build Docker images
+
+on:
+    push:
+        branches: ["main", "develop"]
+        paths:
+            - "apps/api/**"
+
+jobs:
+    build-and-push-dockerfile-image:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Log in to Docker Hub
+              uses: docker/login-action@v3
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }} # Make sure to add the secrets in your repository in -> Settings -> Secrets (Actions) -> New repository secret
+                  password: ${{ secrets.DOCKERHUB_TOKEN }} # Make sure to add the secrets in your repository in -> Settings -> Secrets (Actions) -> New repository secret
+
+            - name: Build and push Docker image
+              uses: docker/build-push-action@v5
+              with:
+                  context: ./apps/api
+                  file: ./Dockerfile
+                  push: true
+                  tags: |
+                      satriadhikara/jejak-api:latest
+                  platforms: linux/amd64

--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -17,5 +17,3 @@ bun.lockb
 dist
 build
 coverage
-
-

--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -1,0 +1,21 @@
+# VCS
+.git
+
+# Dependencies
+node_modules
+bun.lockb
+
+# Local env & editor
+.env
+.env.local
+.env.*.local
+.DS_Store
+.idea
+.vscode
+
+# Build artifacts
+dist
+build
+coverage
+
+

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,17 @@
+FROM oven/bun:latest AS base
+
+WORKDIR /app
+
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile
+
+COPY src ./src
+COPY tsconfig.json ./tsconfig.json
+COPY drizzle.config.ts ./drizzle.config.ts
+
+ENV NODE_ENV=production
+
+EXPOSE 3000
+
+CMD ["bun", "run", "src/index.ts"]
+

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,15 +1,70 @@
-# Elysia with Bun runtime
+# Jejak API (Hono + Bun)
+
+Backend service built with [Hono](https://hono.dev/) on Bun, structured to follow the official best-practice guidance for modular route composition.
 
 ## Getting Started
-To get started with this template, simply paste this command into your terminal:
-```bash
-bun create elysia ./elysia-example
+
+Install dependencies:
+
+```sh
+bun install
 ```
 
-## Development
-To start the development server run:
-```bash
+Run the development server:
+
+```sh
 bun run dev
 ```
 
-Open http://localhost:3000/ with your browser to see the result.
+The app listens on `http://localhost:3000` by default.
+
+## Project Structure
+
+```
+src/
+  app.ts              # Hono instance with global middleware and base path
+  index.ts            # Bun entrypoint exporting { port, fetch }
+  lib/
+    env.ts            # Zod-validated environment loader
+    auth.ts           # Better Auth configuration
+  routes/
+    index.ts          # Registers feature routers with app.route()
+    health.route.ts   # Example feature router (inline handlers per Hono guide)
+  services/
+    health.service.ts # Business logic and Drizzle access (domain-focused)
+  db/
+    schema.ts         # Drizzle schema definitions
+    index.ts          # Drizzle client setup
+```
+
+## Routing Guidelines
+
+- Keep handlers close to their route definitions. Each feature exports a dedicated `Hono` router file (e.g. `routes/health.ts`).
+- Mount feature routers inside `routes/index.ts` via `routes.route("/feature", featureRoutes)`.
+- Avoid Rails-style controller classes; inline handlers preserve Hono’s path-param type inference per the [official guidance](https://hono.dev/docs/guides/best-practices).
+- Use middleware with `app.use()` or within feature routers to layer cross-cutting concerns (auth, logging, etc.).
+
+## Services & Data Access
+
+- Place domain logic and Drizzle ORM calls inside `src/services`. Keep functions pure and return plain data objects.
+- Inject services into route handlers directly; the handler should only parse request input, call the service, and format the response.
+- Share DTOs or validation schemas via dedicated modules (e.g. `src/schemas`) if needed.
+
+## Adding a New Feature
+
+1. Create `src/routes/<feature>.ts` exporting a `new Hono()` instance with inline handlers.
+2. Add any supporting service functions under `src/services/<feature>.service.ts`.
+3. Register the router in `src/routes/index.ts`:
+   ```ts
+   import featureRoutes from "@/routes/feature";
+
+   routes.route("/feature", featureRoutes);
+   ```
+4. Wire up middleware or validation as needed.
+
+Following this pattern keeps the API consistent with Hono’s best practices while leaving room for modular expansion.
+
+## Environment Variables
+
+- Define required variables in `.env` (`DATABASE_URL`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `CLIENT_ORIGIN`, optional `PORT`).
+- `src/lib/env.ts` validates values on startup with Zod v4—misconfigured environments throw immediately with contextual error logs.


### PR DESCRIPTION
This pull request introduces Docker support and updates project documentation for the `apps/api` backend service. The main changes are the addition of Docker configuration files, a workflow for automated Docker image building and pushing, and a comprehensive revision to the README to reflect the current tech stack and project structure.

**Docker Integration:**

* Added a `Dockerfile` to build the API service using Bun, including dependency installation, copying source files, and specifying the entrypoint (`apps/api/Dockerfile`).
* Created a `.dockerignore` file to exclude unnecessary files and directories from the Docker build context, such as VCS, dependencies, environment files, and build artifacts (`apps/api/.dockerignore`).

**CI/CD Automation:**

* Added a GitHub Actions workflow (`.github/workflows/deploy.yaml`) to automatically build and push Docker images to Docker Hub when changes are pushed to `main` or `develop` branches affecting `apps/api`. This workflow handles repository checkout, Docker Hub authentication, and image building/pushing.

**Documentation Update:**

* Overhauled the `README.md` to document the new tech stack (Hono + Bun), project structure, routing guidelines, service/data access patterns, and instructions for Docker and environment setup (`apps/api/README.md`).