### PR TITLE
feat: change default user role from 'user' to 'admin' in schema and auth configuration

### DIFF
--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -48,7 +48,7 @@ export const user = pgTable("user", {
     .$onUpdate(() => new Date())
     .notNull(),
   points: integer("points").default(0),
-  role: text("role").default("user").notNull(),
+  role: text("role").default("admin").notNull(),
 });
 
 export const session = pgTable("session", {

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -27,7 +27,7 @@ export const auth = betterAuth({
       role: {
         type: "string",
         required: true,
-        defaultValue: "user",
+        defaultValue: "admin",
         input: false,
       },
     },


### PR DESCRIPTION
This pull request updates the default user role in both the database schema and the authentication logic. The main effect is that new users will now be assigned the "admin" role by default instead of "user".

**User role default changes:**

* Changed the default value for the `role` field in the `user` table schema from `"user"` to `"admin"` in `apps/api/src/db/schema.ts`.
* Updated the default value for the `role` field in the authentication configuration from `"user"` to `"admin"` in `apps/api/src/lib/auth.ts`.